### PR TITLE
MAINT: Fix Dockerfile instructions

### DIFF
--- a/kubernetes-embedded-testing/Dockerfile
+++ b/kubernetes-embedded-testing/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.24
 
-copy . .
+COPY . .
 
-RUN make build && \
-  cp ./bin/ket /usr/local/bin/ket && \
-  rm -rf .
+RUN make build \
+  && ls -l ./bin \
+  && cp ./bin/ket /usr/local/bin/ket


### PR DESCRIPTION
This commit updates the Dockerfile to use COPY instead of copy and adds ls -l ./bin to the build process for better visibility.