### PR TITLE
MAINT: Enable CGO by default for all Go commands in Makefile

### DIFF
--- a/kubernetes-embedded-testing/makefile
+++ b/kubernetes-embedded-testing/makefile
@@ -5,7 +5,7 @@ DOCKER_IMAGE=ket:latest
 GO_FILES=$(shell find . -name "*.go" -type f)
 
 # Go parameters
-GOCMD=go
+GOCMD=CGO_ENABLED=0 go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test


### PR DESCRIPTION
This commit modifies the Makefile to set CGO_ENABLED=0 for all Go commands by default.