### PR TITLE
feat(rbac): Allow for custom RBAC policies to be configured with ket

### DIFF
--- a/example/rbac/ket-config.yaml
+++ b/example/rbac/ket-config.yaml
@@ -1,0 +1,23 @@
+# Example ket-config.yaml for RBAC configuration
+#
+# This configuration file demonstrates how to use custom RBAC rules with ket.
+# Place this file in your project directory and ket will automatically load it,
+# or specify a custom path with --config flag.
+
+# Path to additional RBAC rules file (relative to this config file or absolute path)
+rbac: manifests/rbac-rules.yaml
+
+# Other optional configuration options:
+# namespacePrefix: "my-test"
+# image: "node:18-alpine"
+# backoffLimit: 2
+# activeDeadlineS: 1800
+# projectRoot: "."
+# clusterWorkspacePath: "/workspace"
+# keepNamespace: false
+# debug: false
+
+# Logging configuration
+logging:
+  prefix: true
+  timestamp: false

--- a/example/rbac/manifests/rbac-rules.yaml
+++ b/example/rbac/manifests/rbac-rules.yaml
@@ -1,0 +1,15 @@
+# Additional RBAC Rules for OpenFeature Support
+#
+# This file adds RBAC permissions for OpenFeature resources.
+# Use this when your tests need to interact with OpenFeature FeatureFlags and FeatureFlagConfigurations.
+#
+# These rules will be merged with the default RBAC rules provided by ket.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openfeature-featureflag-reader
+rules:
+  - apiGroups: ["core.openfeature.dev"]
+    resources: ["featureflags", "featureflagconfigurations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/kubernetes-embedded-testing/cmd/testrunner/flag_config.go
+++ b/kubernetes-embedded-testing/cmd/testrunner/flag_config.go
@@ -58,6 +58,11 @@ var FlagMapping = struct {
 				"Must include dependencies for the test command (e.g., mocha or other test runners).",
 			Default: "atidyshirt/kubernetes-embedded-test-runner-base:latest",
 		},
+		"rbac": {
+			ViperKey:    "rbac",
+			Description: "Extra Yaml configuration to load into the rbac options",
+			Default:     "",
+		},
 		"test-command": {
 			ViperKey:    "testCommand",
 			Description: "Command to execute inside the test runner pod (e.g., 'mocha **/*.spec.ts').",

--- a/kubernetes-embedded-testing/pkg/config/config.go
+++ b/kubernetes-embedded-testing/pkg/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	BackoffLimit    int32           `mapstructure:"backoffLimit" yaml:"backoffLimit" json:"backoffLimit"`
 	ActiveDeadlineS int64           `mapstructure:"activeDeadlineS" yaml:"activeDeadlineS" json:"activeDeadlineS"`
 	WorkspacePath   string          `mapstructure:"clusterWorkspacePath" yaml:"clusterWorkspacePath" json:"clusterWorkspacePath"`
+	RbacFile        string          `mapstructure:"rbac" yaml:"rbac" json:"rbac"`
 	Logging         LoggingConfig   `mapstructure:"logging" yaml:"logging" json:"logging"`
 	Ctx             context.Context `mapstructure:"-" yaml:"-" json:"-"`
 }

--- a/kubernetes-embedded-testing/pkg/kube/apply/rbac.go
+++ b/kubernetes-embedded-testing/pkg/kube/apply/rbac.go
@@ -5,16 +5,29 @@ import (
 	"fmt"
 	"strings"
 
+	"testrunner/pkg/config"
 	"testrunner/pkg/kube/generate"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // RBAC creates the necessary RBAC resources for the test namespace
-func RBAC(ctx context.Context, client *kubernetes.Clientset, namespace string) error {
+func RBAC(ctx context.Context, client *kubernetes.Clientset, namespace string, cfg *config.Config) error {
 	serviceAccount := generate.ServiceAccount(namespace)
-	role := generate.Role(namespace)
+	
+	// Load additional RBAC rules from file if specified
+	var additionalRules []rbacv1.PolicyRule
+	if cfg != nil && cfg.RbacFile != "" {
+		rules, err := generate.LoadRBACRulesFromFile(cfg.RbacFile)
+		if err != nil {
+			return fmt.Errorf("failed to load RBAC rules from file: %w", err)
+		}
+		additionalRules = rules
+	}
+	
+	role := generate.Role(namespace, additionalRules...)
 	roleBinding := generate.RoleBinding(namespace)
 
 	_, err := client.CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})

--- a/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
+++ b/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
@@ -20,6 +20,11 @@ func GetTestRunnerRBACRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"get", "list", "create"},
 		},
 		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments", "statefulsets", "daemonsets"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
@@ -52,7 +57,12 @@ func ServiceAccount(namespace string) *corev1.ServiceAccount {
 }
 
 // Role generates a role manifest
-func Role(namespace string) *rbacv1.Role {
+func Role(namespace string, additionalRules ...rbacv1.PolicyRule) *rbacv1.Role {
+	rules := GetTestRunnerRBACRules()
+	if len(additionalRules) > 0 {
+		rules = MergeRBACRules(rules, additionalRules)
+	}
+	
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -62,7 +72,7 @@ func Role(namespace string) *rbacv1.Role {
 			Name:      "ket-test-runner",
 			Namespace: namespace,
 		},
-		Rules: GetTestRunnerRBACRules(),
+		Rules: rules,
 	}
 }
 

--- a/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
+++ b/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
@@ -58,10 +58,7 @@ func ServiceAccount(namespace string) *corev1.ServiceAccount {
 
 // Role generates a role manifest
 func Role(namespace string, additionalRules ...rbacv1.PolicyRule) *rbacv1.Role {
-	rules := GetTestRunnerRBACRules()
-	if len(additionalRules) > 0 {
-		rules = MergeRBACRules(rules, additionalRules)
-	}
+	rules := MergeRBACRules(GetTestRunnerRBACRules(), additionalRules)
 	
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{

--- a/kubernetes-embedded-testing/pkg/kube/generate/rbac_loader.go
+++ b/kubernetes-embedded-testing/pkg/kube/generate/rbac_loader.go
@@ -1,0 +1,46 @@
+package generate
+
+import (
+	"fmt"
+	"os"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// RBACRulesFile represents the structure of an RBAC rules YAML file
+type RBACRulesFile struct {
+	Rules []rbacv1.PolicyRule `yaml:"rules" json:"rules"`
+}
+
+// LoadRBACRulesFromFile loads additional RBAC rules from a YAML file
+func LoadRBACRulesFromFile(filepath string) ([]rbacv1.PolicyRule, error) {
+	if filepath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RBAC file %s: %w", filepath, err)
+	}
+
+	var rbacFile RBACRulesFile
+	if err := yaml.Unmarshal(data, &rbacFile); err != nil {
+		return nil, fmt.Errorf("failed to parse RBAC file %s: %w", filepath, err)
+	}
+
+	return rbacFile.Rules, nil
+}
+
+// MergeRBACRules merges default RBAC rules with additional rules from a file
+func MergeRBACRules(defaultRules []rbacv1.PolicyRule, additionalRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	if len(additionalRules) == 0 {
+		return defaultRules
+	}
+
+	merged := make([]rbacv1.PolicyRule, len(defaultRules))
+	copy(merged, defaultRules)
+	merged = append(merged, additionalRules...)
+	
+	return merged
+}

--- a/kubernetes-embedded-testing/pkg/launcher/launch.go
+++ b/kubernetes-embedded-testing/pkg/launcher/launch.go
@@ -45,7 +45,7 @@ func RunLaunch(cfg config.Config) error {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	err = apply.RBAC(ctx, client, createdNamespace)
+	err = apply.RBAC(ctx, client, createdNamespace, &cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create RBAC resources: %w", err)
 	}


### PR DESCRIPTION
This patch allows for custom rbac file to be provided to configure extra
rbac rules for the test runner pod. This will allow for things like
OpenFeature to have RBAC policies honored by the testing system.

Implementation is as follows:

- Allow a new option `--rbac` to pass a file containing RBAC rules to KET.
- The `--rbac` file gets merged into the existing default RBAC rules.
- Integration test updated to encompass new behaviour.
