### PR TITLE
ATCLOUD-249: Use ClusterRole instead of Role

### DIFF
--- a/kubernetes-embedded-testing/pkg/kube/generate/integration_test.go
+++ b/kubernetes-embedded-testing/pkg/kube/generate/integration_test.go
@@ -34,7 +34,7 @@ func TestRole_GeneratesCorrectManifest(t *testing.T) {
 	role := Role(namespace)
 
 	assert.Equal(t, "rbac.authorization.k8s.io/v1", role.APIVersion)
-	assert.Equal(t, "Role", role.Kind)
+	assert.Equal(t, "ClusterRole", role.Kind)
 	assert.Equal(t, "ket-test-runner", role.Name)
 	assert.Equal(t, namespace, role.Namespace)
 	assert.NotEmpty(t, role.Rules)
@@ -45,14 +45,14 @@ func TestRoleBinding_GeneratesCorrectManifest(t *testing.T) {
 	rb := RoleBinding(namespace)
 
 	assert.Equal(t, "rbac.authorization.k8s.io/v1", rb.APIVersion)
-	assert.Equal(t, "RoleBinding", rb.Kind)
+	assert.Equal(t, "ClusterRoleBinding", rb.Kind)
 	assert.Equal(t, "ket-test-runner", rb.Name)
 	assert.Equal(t, namespace, rb.Namespace)
 	assert.Len(t, rb.Subjects, 1)
 	assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
 	assert.Equal(t, "default", rb.Subjects[0].Name)
 	assert.Equal(t, namespace, rb.Subjects[0].Namespace)
-	assert.Equal(t, "Role", rb.RoleRef.Kind)
+	assert.Equal(t, "ClusterRole", rb.RoleRef.Kind)
 	assert.Equal(t, "ket-test-runner", rb.RoleRef.Name)
 }
 
@@ -300,7 +300,7 @@ func TestRole_WithAdditionalRules(t *testing.T) {
 	role := Role(namespace, additionalRules...)
 
 	assert.Equal(t, "rbac.authorization.k8s.io/v1", role.APIVersion)
-	assert.Equal(t, "Role", role.Kind)
+	assert.Equal(t, "ClusterRole", role.Kind)
 	assert.Equal(t, "ket-test-runner", role.Name)
 	assert.Equal(t, namespace, role.Namespace)
 	

--- a/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
+++ b/kubernetes-embedded-testing/pkg/kube/generate/rbac.go
@@ -63,7 +63,7 @@ func Role(namespace string, additionalRules ...rbacv1.PolicyRule) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "Role",
+			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ket-test-runner",
@@ -78,7 +78,7 @@ func RoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "RoleBinding",
+			Kind:       "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ket-test-runner",
@@ -92,7 +92,7 @@ func RoleBinding(namespace string) *rbacv1.RoleBinding {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
+			Kind:     "ClusterRole",
 			Name:     "ket-test-runner",
 			APIGroup: "rbac.authorization.k8s.io",
 		},

--- a/kubernetes-embedded-testing/pkg/kube/manifest/integration_test.go
+++ b/kubernetes-embedded-testing/pkg/kube/manifest/integration_test.go
@@ -37,8 +37,8 @@ func TestAll_GeneratesValidYAML(t *testing.T) {
 	allManifests := strings.Join(manifests, "\n")
 	assert.Contains(t, allManifests, "kind: Namespace")
 	assert.Contains(t, allManifests, "kind: ServiceAccount")
-	assert.Contains(t, allManifests, "kind: Role")
-	assert.Contains(t, allManifests, "kind: RoleBinding")
+	assert.Contains(t, allManifests, "kind: ClusterRole")
+	assert.Contains(t, allManifests, "kind: ClusterRoleBinding")
 	assert.Contains(t, allManifests, "kind: Job")
 }
 

--- a/kubernetes-embedded-testing/pkg/launcher/integration_test.go
+++ b/kubernetes-embedded-testing/pkg/launcher/integration_test.go
@@ -39,8 +39,8 @@ func TestRunManifest_GeneratesValidYAML(t *testing.T) {
 	outputStr := string(output)
 	assert.Contains(t, outputStr, "kind: Namespace")
 	assert.Contains(t, outputStr, "kind: ServiceAccount")
-	assert.Contains(t, outputStr, "kind: Role")
-	assert.Contains(t, outputStr, "kind: RoleBinding")
+	assert.Contains(t, outputStr, "kind: ClusterRole")
+	assert.Contains(t, outputStr, "kind: ClusterRoleBinding")
 	assert.Contains(t, outputStr, "kind: Job")
 
 	// Verify YAML structure
@@ -175,7 +175,7 @@ func TestRunManifest_RBACConfiguration(t *testing.T) {
 
 	// Verify RoleBinding
 	assert.Contains(t, outputStr, "kind: ServiceAccount")
-	assert.Contains(t, outputStr, "kind: Role")
+	assert.Contains(t, outputStr, "kind: ClusterRole")
 }
 
 func TestRunManifest_JobConfiguration(t *testing.T) {


### PR DESCRIPTION
This patch updates Role to ClusterRole and RoleBinding to
ClusterRoleBinding. We did this because we need to install some
CRDs. CRDs are installed in the cluster level so we need
ClusterRole to do this.

Reviewed-by: Jordan Pyott <jordan.pyott@alliedtelesis.co.nz>
Reviewed-by: Martin Hill <martin.hill@alliedtelesis.co.nz>
