### PR TITLE
ATCLOUD-501: Add Namespace option

### DIFF
--- a/kubernetes-embedded-testing/cmd/testrunner/flag_config.go
+++ b/kubernetes-embedded-testing/cmd/testrunner/flag_config.go
@@ -35,6 +35,11 @@ var FlagMapping = struct {
 			Description: "Prefix for the namespace name e.g. kubernetes-embedded-test-nodejs-example",
 			Default:     "kubernetes-embedded-test",
 		},
+		"namespace": {
+			ViperKey:    "namespace",
+			Description: "name-space to use within cluster. Overrides any ns-prefix setting",
+			Default:     "",
+		},
 		"debug": {
 			ViperKey:    "debug",
 			Description: "Enable debug logging",

--- a/kubernetes-embedded-testing/pkg/config/config.go
+++ b/kubernetes-embedded-testing/pkg/config/config.go
@@ -15,6 +15,7 @@ type LoggingConfig struct {
 type Config struct {
 	Mode            string          `mapstructure:"mode" yaml:"mode" json:"mode"`
 	NamespacePrefix string          `mapstructure:"namespacePrefix" yaml:"namespacePrefix" json:"namespacePrefix"`
+	Namespace       string          `mapstructure:"namespace" yaml:"namespace" json:"namespace"`
 	ProjectRoot     string          `mapstructure:"projectRoot" yaml:"projectRoot" json:"projectRoot"`
 	Image           string          `mapstructure:"image" yaml:"image" json:"image"`
 	Debug           bool            `mapstructure:"debug" yaml:"debug" json:"debug"`

--- a/kubernetes-embedded-testing/pkg/kube/apply/execution.go
+++ b/kubernetes-embedded-testing/pkg/kube/apply/execution.go
@@ -170,11 +170,17 @@ func getPodStatus(pod corev1.Pod) string {
 
 // isPodReadyForLogs checks if the pod is ready to stream logs from
 func isPodReadyForLogs(pod corev1.Pod) bool {
+
 	if len(pod.Status.ContainerStatuses) == 0 {
 		return false
 	}
 
 	containerStatus := pod.Status.ContainerStatuses[0]
+
+	if containerStatus.State.Terminated != nil {
+		return true
+	}
+
 	return containerStatus.State.Running != nil && containerStatus.Ready
 }
 

--- a/kubernetes-embedded-testing/pkg/launcher/launch.go
+++ b/kubernetes-embedded-testing/pkg/launcher/launch.go
@@ -8,6 +8,7 @@ import (
 	"testrunner/pkg/config"
 	"testrunner/pkg/kube/apply"
 	"testrunner/pkg/logger"
+	 metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestExecutionError represents a test execution failure with an exit code
@@ -91,6 +92,12 @@ func RunLaunch(cfg config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to wait for test completion: %w", err)
 	}
+
+	logger.LauncherLogger.Info("Deleting job %s...", job.Name)
+	policy := metav1.DeletePropagationBackground
+	err = client.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+		PropagationPolicy: &policy,
+	})
 
 	if !result.Success {
 		return &TestExecutionError{

--- a/kubernetes-embedded-testing/pkg/launcher/utils.go
+++ b/kubernetes-embedded-testing/pkg/launcher/utils.go
@@ -10,13 +10,17 @@ import (
 
 // generateTestNamespace generates a unique test namespace name using cleaned cfg.NamespacePrefix + UUID
 func generateTestNamespace(cfg config.Config) string {
-	prefix := cfg.NamespacePrefix
-	if prefix == "" {
-		prefix = "kubernetes-embedded-test"
+        namespace := cfg.Namespace
+	if namespace == "" {
+		prefix := cfg.NamespacePrefix
+		if prefix == "" {
+    		       prefix = "kubernetes-embedded-test"
+    	        }
+    	        cleanPrefix := toKubeSafe(prefix)
+    	        namespaceUUID := uuid.New().String()[:8]
+    	        namespace = fmt.Sprintf("%s-%s", cleanPrefix, namespaceUUID)
 	}
-	cleanPrefix := toKubeSafe(prefix)
-	namespaceUUID := uuid.New().String()[:8]
-	return fmt.Sprintf("%s-%s", cleanPrefix, namespaceUUID)
+	return namespace
 }
 
 // toKubeSafe converts a string to a Kubernetes-safe form: non-alphanumerics replaced with hyphens

--- a/kubernetes-embedded-testing/pkg/launcher/utils_test.go
+++ b/kubernetes-embedded-testing/pkg/launcher/utils_test.go
@@ -80,3 +80,18 @@ func TestGenerateTestNamespace_LengthAndFormat(t *testing.T) {
 	uuidPattern := regexp.MustCompile(`^[a-f0-9]{8}$`)
 	assert.True(t, uuidPattern.MatchString(uuidPart))
 }
+
+func TestGenerateTestNamespace_Namespace(t *testing.T) {
+	cfg := config.Config{Namespace: "test-namespace"}
+	namespace := generateTestNamespace(cfg)
+        assert.Equal(t, "test-namespace", namespace)
+}
+
+func TestGenerateTestNamespace_NamespaceOverride(t *testing.T) {
+	cfg := config.Config{
+		Namespace:       "test-namespace",
+		NamespacePrefix: "kubernetes-embedded-test",
+ 	}
+	namespace := generateTestNamespace(cfg)
+	assert.Equal(t, "test-namespace", namespace)
+}


### PR DESCRIPTION
When set will be used as the namespace for the job.

When name space set any prefix for the namespace is ignored.

The reason is to allow ket to be used to setup deployments then re-use the same namespace in later tests.